### PR TITLE
docs: add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,19 @@
+# Security Policy
+
+## Security advisories
+
+Security advisories can be found on the
+[LoopBack website](https://loopback.io/doc/en/sec/index.html).
+
+## Reporting a vulnerability
+
+If you think you have discovered a new security issue with any LoopBack package,
+**please do not report it on GitHub**. Instead, send an email to
+[security@loopback.io](mailto:security@loopback.io) with the following details:
+
+- Full description of the vulnerability.
+- Steps to reproduce the issue.
+- Possible solutions.
+
+If you are sending us any logs as part of the report, then make sure to redact
+any sensitive data from them.


### PR DESCRIPTION
Signed-off-by: Diana Lau <dhmlau@ca.ibm.com>


Using https://github.com/loopbackio/loopback-next/blob/master/SECURITY.md as a reference.

Related to https://github.com/loopbackio/loopback-governance/issues/24